### PR TITLE
Change ignoring rule for sys crate

### DIFF
--- a/src/codegen/sys/ffi_type.rs
+++ b/src/codegen/sys/ffi_type.rs
@@ -95,7 +95,7 @@ fn fix_external_name(env: &Env, type_id: library::TypeId, name: &str) -> Result 
     } else {
         let name_with_prefix = format!("{}_ffi::{}",
             fix_namespace(env, type_id), name);
-        if env.type_status(&type_id.full_name(&env.library)) == GStatus::Ignore {
+        if env.type_status_sys(&type_id.full_name(&env.library)) == GStatus::Ignore {
             Err(name_with_prefix.into())
         } else {
             Ok(name_with_prefix)
@@ -109,7 +109,7 @@ fn fix_namespace(env: &Env, type_id: library::TypeId) -> String {
     name = match name {
         "gdk_pixbuf" => "gdk",
         "gio" => "glib",
-        "gobject" => "glib",
+        "g_object" => "glib",
         _ => name,
     };
     name.into()

--- a/src/env.rs
+++ b/src/env.rs
@@ -16,4 +16,8 @@ impl Env {
         self.config.objects.get(name).map(|o| o.status)
             .unwrap_or(Default::default())
     }
+    pub fn type_status_sys(&self, name: &str) -> GStatus {
+        self.config.objects.get(name).map(|o| o.status)
+            .unwrap_or(GStatus::Generate)
+    }
 }


### PR DESCRIPTION
For fully compilable we need fix really unimplemented types in Gir.toml.
I started adding, but have no time until the evening. 48 errors to go.
Also I noticed an unpleasant thing: when changing Gir.toml, `cargo run` recompile the project, and not just launches.
```
[[object]]
name = "Gdk.ModifierType"
status = "ignore"

[[object]]
name = "Gdk.Gravity"
status = "ignore"

[[object]]
name = "Gio.File"
status = "ignore"

[[object]]
name = "Gio.Icon"
status = "ignore"

[[object]]
name = "Pango.FontFace"
status = "ignore"
```