### PR TITLE
library: change glib_type_name to c_type for Enumeration and Bitfield

### DIFF
--- a/src/codegen/sys/lib_.rs
+++ b/src/codegen/sys/lib_.rs
@@ -89,7 +89,7 @@ fn generate_bitfields<W: Write>(w: &mut W, ns_name: &str, items: &[&library::Bit
                           tabs(2), strip_prefix(ns_name, &member.c_identifier), member.value));
         }
         try!(writeln!(w, "{}}}\n}}", tabs(1)));
-        try!(writeln!(w, "pub type {} = {};", item.glib_type_name, item.name));
+        try!(writeln!(w, "pub type {} = {};", item.c_type, item.name));
         try!(writeln!(w, ""));
     }
 
@@ -112,7 +112,7 @@ fn generate_enums<W: Write>(w: &mut W, ns_name: &str, items: &[&library::Enumera
                           strip_prefix(ns_name, &member.c_identifier),
                           item.name, member.name.to_camel()));
         }
-        try!(writeln!(w, "pub type {} = {};", item.glib_type_name, item.name));
+        try!(writeln!(w, "pub type {} = {};", item.c_type, item.name));
         try!(writeln!(w, ""));
     }
 

--- a/src/library.rs
+++ b/src/library.rs
@@ -183,14 +183,14 @@ pub struct Member {
 
 pub struct Enumeration {
     pub name: String,
-    pub glib_type_name: String,
+    pub c_type: String,
     pub members: Vec<Member>,
     pub functions: Vec<Function>,
 }
 
 pub struct Bitfield {
     pub name: String,
-    pub glib_type_name: String,
+    pub c_type: String,
     pub members: Vec<Member>,
     pub functions: Vec<Function>,
 }
@@ -284,9 +284,9 @@ macro_rules! impl_lexical_ord {
 }
 
 impl_lexical_ord!(
-    Bitfield => glib_type_name,
+    Bitfield => c_type,
     Class => glib_type_name,
-    Enumeration => glib_type_name,
+    Enumeration => c_type,
     Function => c_identifier,
     Interface => glib_type_name,
     Record => glib_type_name,
@@ -333,8 +333,8 @@ impl Type {
         use self::Type::*;
         match self {
             &Alias(ref alias) => Some(&alias.c_identifier),
-            &Enumeration(ref enum_) => Some(&enum_.glib_type_name),
-            &Bitfield(ref bit_field) => Some(&bit_field.glib_type_name),
+            &Enumeration(ref enum_) => Some(&enum_.c_type),
+            &Bitfield(ref bit_field) => Some(&bit_field.c_type),
             &Record(ref rec) => Some(&rec.glib_type_name),
             &Union(ref union) => Some(&union.glib_type_name),
             &Function(ref func) => func.c_identifier.as_ref().map(|s| &s[..]),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -389,7 +389,10 @@ impl Library {
 
     fn read_bitfield(&mut self, parser: &mut Reader, ns_id: u16,
                      attrs: &Attributes) -> Result<(), Error> {
-        let name = try!(attrs.get("name").ok_or_else(|| mk_error!("Missing bitfield name", parser)));
+        let name = try!(attrs.get("name")
+                        .ok_or_else(|| mk_error!("Missing bitfield name", parser)));
+        let c_type = try!(attrs.get("type")
+                          .ok_or_else(|| mk_error!("Missing c:type attribute", parser)));
         let mut members = Vec::new();
         let mut fns = Vec::new();
         loop {
@@ -418,11 +421,10 @@ impl Library {
             }
         }
 
-        let type_name = attrs.get("type-name").unwrap_or(name);
         let typ = Type::Bitfield(
             Bitfield {
                 name: name.into(),
-                glib_type_name: type_name.into(),
+                c_type: c_type.into(),
                 members: members,
                 functions: fns,
             });
@@ -432,7 +434,10 @@ impl Library {
 
     fn read_enumeration(&mut self, parser: &mut Reader, ns_id: u16,
                         attrs: &Attributes) -> Result<(), Error> {
-        let name = try!(attrs.get("name").ok_or_else(|| mk_error!("Missing enumeration name", parser)));
+        let name = try!(attrs.get("name")
+                        .ok_or_else(|| mk_error!("Missing enumeration name", parser)));
+        let c_type = try!(attrs.get("type")
+                          .ok_or_else(|| mk_error!("Missing c:type attribute", parser)));
         let mut members = Vec::new();
         let mut fns = Vec::new();
         loop {
@@ -461,11 +466,10 @@ impl Library {
             }
         }
 
-        let type_name = attrs.get("type-name").unwrap_or(name);
         let typ = Type::Enumeration(
             Enumeration {
                 name: name.into(),
-                glib_type_name: type_name.into(),
+                c_type: c_type.into(),
                 members: members,
                 functions: fns,
             });


### PR DESCRIPTION
...and make the attribute mandatory. Unlike glib:type-name it's always present.