### PR TITLE
Wrap extern fns in Option

### DIFF
--- a/src/codegen/sys/functions.rs
+++ b/src/codegen/sys/functions.rs
@@ -51,7 +51,7 @@ pub fn generate_callbacks<W: Write>(w: &mut W, env: &Env, callbacks: &[&library:
     for func in callbacks {
         let (commented, sig) = function_signature(env, func, true);
         let comment = if commented { "//" } else { "" };
-        try!(writeln!(w, "{}pub type {} = unsafe extern \"C\" fn{};",
+        try!(writeln!(w, "{}pub type {} = Option<unsafe extern \"C\" fn{}>;",
                       comment, func.c_identifier.as_ref().unwrap(), sig));
     }
 

--- a/src/codegen/sys/lib_.rs
+++ b/src/codegen/sys/lib_.rs
@@ -241,7 +241,7 @@ fn generate_records<W: Write>(w: &mut W, env: &Env, records: &[&library::Record]
                 if let Some(ref func) =
                         env.library.type_(field.typ).maybe_ref_as::<library::Function>() {
                     let (com, sig) = functions::function_signature(env, func, true);
-                    lines.push(format!("{}{}{}: fn{},", tabs(1), vis, name, sig));
+                    lines.push(format!("{}{}{}: Option<unsafe extern \"C\" fn{}>,", tabs(1), vis, name, sig));
                     commented |= com;
                 }
                 else if let Some(c_type) = env.library.type_(field.typ).get_glib_name() {


### PR DESCRIPTION
An fn type is not nullable so the more faithful representation of the C type is wrapping in an Option.