### PR TITLE
Generate consts

### DIFF
--- a/src/analysis/implements.rs
+++ b/src/analysis/implements.rs
@@ -4,7 +4,6 @@ use std::vec::Vec;
 use analysis::rust_type::used_rust_type;
 use env::Env;
 use super::general::StatusedTypeId;
-use gobjects::*;
 use library;
 
 pub fn analyze(env: &Env, type_: &library::Class, used_types: &mut HashSet<String>)
@@ -14,7 +13,7 @@ pub fn analyze(env: &Env, type_: &library::Class, used_types: &mut HashSet<Strin
     for &interface_tid in &type_.implements {
         let status = env.type_status(&interface_tid.full_name(&env.library));
 
-        if status == GStatus::Ignore { continue }
+        if status.ignored() { continue }
 
         let name = env.type_(interface_tid).get_name();
 

--- a/src/analysis/object.rs
+++ b/src/analysis/object.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 
 use env::Env;
-use gobjects::{GObject, GStatus};
+use gobjects::GObject;
 use library;
 use nameutil::*;
 use super::*;
@@ -68,7 +68,7 @@ pub fn new(env: &Env, obj: &GObject) -> Info {
         let status = env.config.objects.get(&child_name)
             .map(|o| o.status)
             .unwrap_or(Default::default());
-        if status == GStatus::Manual || status == GStatus::Generate {
+        if status.normal() {
             has_children = true;
             break;
         }

--- a/src/analysis/parents.rs
+++ b/src/analysis/parents.rs
@@ -4,7 +4,6 @@ use std::vec::Vec;
 use analysis::rust_type::used_rust_type;
 use env::Env;
 use super::general::StatusedTypeId;
-use gobjects::*;
 use library::Class;
 use traits::*;
 
@@ -25,7 +24,7 @@ pub fn analyze(env: &Env, type_: &Class, used_types: &mut HashSet<String>)
         });
         used_rust_type(env, parent_tid).ok().map(|s| used_types.insert(s));
 
-        if status == GStatus::Ignore { has_ignored_parents = true; }
+        if status.ignored() { has_ignored_parents = true; }
 
         if parent_type.c_type == "GtkWidget" { break }
     }

--- a/src/analysis/rust_type.rs
+++ b/src/analysis/rust_type.rs
@@ -1,7 +1,6 @@
 use std::result;
 
 use env::Env;
-use gobjects::GStatus;
 use library;
 use nameutil::crate_name;
 use traits::*;
@@ -60,7 +59,7 @@ pub fn rust_type(env: &Env, type_id: library::TypeId) -> Result {
     } else {
         let rust_type_with_prefix = rust_type.map(|s| format!("{}::{}",
             crate_name(&env.library.namespace(type_id.ns_id).name), s));
-        if env.type_status(&type_id.full_name(&env.library)) == GStatus::Ignore {
+        if env.type_status(&type_id.full_name(&env.library)).ignored() {
             Err(rust_type_with_prefix.as_str().into())
         } else {
             rust_type_with_prefix

--- a/src/codegen/sys/ffi_type.rs
+++ b/src/codegen/sys/ffi_type.rs
@@ -1,6 +1,5 @@
 use analysis::rust_type::Result;
 use env::Env;
-use gobjects::GStatus;
 use library;
 use library::*;
 use nameutil::crate_name;
@@ -159,7 +158,7 @@ fn fix_name(env: &Env, type_id: library::TypeId, name: &str) -> Result {
         } else {
             format!("{}_ffi::{}", fix_namespace(env, type_id), name)
         };
-        if env.type_status_sys(&type_id.full_name(&env.library)) == GStatus::Ignore {
+        if env.type_status_sys(&type_id.full_name(&env.library)).ignored() {
             Err(name_with_prefix)
         } else {
             Ok(name_with_prefix)

--- a/src/codegen/sys/lib_.rs
+++ b/src/codegen/sys/lib_.rs
@@ -7,7 +7,6 @@ use case::CaseExt;
 use analysis::rust_type::parameter_rust_type;
 use env::Env;
 use file_saver::*;
-use gobjects::GStatus;
 use library;
 use nameutil::*;
 use super::ffi_type::ffi_type;
@@ -129,7 +128,8 @@ fn generate_constants<W: Write>(w: &mut W, env: &Env, constants: &[library::Cons
             Ok(x) => ("", x),
             Err(x) => ("//", x),
         };
-        if env.type_status_sys(&format!("{}.{}", env.config.library_name, constant.name)) == GStatus::Ignore {
+        if env.type_status_sys(&format!("{}.{}", env.config.library_name,
+            constant.name)).ignored() {
             comment = "//";
         }
         let mut value = constant.value.clone();

--- a/src/codegen/sys/lib_.rs
+++ b/src/codegen/sys/lib_.rs
@@ -7,6 +7,7 @@ use case::CaseExt;
 use analysis::rust_type::parameter_rust_type;
 use env::Env;
 use file_saver::*;
+use gobjects::GStatus;
 use library;
 use nameutil::*;
 use super::ffi_type::ffi_type;
@@ -124,10 +125,13 @@ fn generate_bitfields<W: Write>(w: &mut W, items: &[&library::Bitfield])
 fn generate_constants<W: Write>(w: &mut W, env: &Env, constants: &[library::Constant]) -> Result<()> {
     try!(writeln!(w, ""));
     for constant in constants {
-        let (comment, mut type_) = match parameter_rust_type(env, constant.typ, library::ParameterDirection::In) {
+        let (mut comment, mut type_) = match parameter_rust_type(env, constant.typ, library::ParameterDirection::In) {
             Ok(x) => ("", x),
             Err(x) => ("//", x),
         };
+        if env.type_status_sys(&format!("{}.{}", env.config.library_name, constant.name)) == GStatus::Ignore {
+            comment = "//";
+        }
         let mut value = constant.value.clone();
         if type_ == "&str" {
             type_ = "&'static str".into();

--- a/src/codegen/sys/lib_.rs
+++ b/src/codegen/sys/lib_.rs
@@ -135,27 +135,13 @@ fn generate_constants<W: Write>(w: &mut W, env: &Env, constants: &[library::Cons
         let mut value = constant.value.clone();
         if type_ == "&str" {
             type_ = "&'static str".into();
-            value = format!("\"{}\"", escape_string(&value));
+            value = format!("r##\"{}\"##", value);
         }
         try!(writeln!(w, "{}pub const {}:{} = {};", comment,
             constant.c_identifier, type_, value));
     }
 
     Ok(())
-}
-
-fn escape_string(s: &str) -> String {
-    let mut es = String::with_capacity(s.len() * 2);
-    let _ = s.chars().map(|c| {
-        match c {
-            '\'' | '\"' | '\\' => {
-                es.push('\\');
-                es.push(c)
-            }
-            _ => es.push(c),
-        }
-    }).count();
-    es
 }
 
 fn generate_enums<W: Write>(w: &mut W, items: &[&library::Enumeration])

--- a/src/codegen/sys/statics.rs
+++ b/src/codegen/sys/statics.rs
@@ -5,7 +5,7 @@ use super::super::general::write_vec;
 pub fn begin<W: Write>(w: &mut W) -> Result<()>{
     let v = vec![
 "",
-"#![allow(non_camel_case_types)]",
+"#![allow(non_camel_case_types, non_upper_case_globals)]",
 "",
 "extern crate libc;",
 "#[macro_use] extern crate bitflags;",
@@ -58,14 +58,6 @@ pub fn only_for_gtk<W: Write>(w: &mut W) -> Result<()>{
     let v = vec![
 "",
 "pub const GTK_ENTRY_BUFFER_MAX_SIZE: u16 = ::std::u16::MAX;",
-"",
-"//pub type GtkTreeModelForeachFunc = fn(model: *mut GtkTreeModel, path: *mut GtkTreePath, iter: *mut GtkTreeIter, data: gpointer) -> gboolean;",
-"",
-"pub const GTK_STYLE_PROVIDER_PRIORITY_FALLBACK: u32 = 1;",
-"pub const GTK_STYLE_PROVIDER_PRIORITY_THEME: u32 = 200;",
-"pub const GTK_STYLE_PROVIDER_PRIORITY_SETTINGS: u32 = 400;",
-"pub const GTK_STYLE_PROVIDER_PRIORITY_APPLICATION: u32 = 600;",
-"pub const GTK_STYLE_PROVIDER_PRIORITY_USER: u32 = 800;",
     ];
 
     write_vec(w, &v)

--- a/src/codegen/widgets.rs
+++ b/src/codegen/widgets.rs
@@ -4,14 +4,13 @@ use analysis;
 use analysis::general::is_widget;
 use env::Env;
 use file_saver::*;
-use gobjects::*;
 use nameutil::*;
 
 pub fn generate(env: &Env) {
     let root_path = PathBuf::from(&env.config.target_path).join("src").join("widgets");
 
     for obj in env.config.objects.values() {
-        if obj.status != GStatus::Generate || !is_widget(&obj.name, &env.library){
+        if obj.status.need_generate() || !is_widget(&obj.name, &env.library){
             continue;
         }
 

--- a/src/gobjects.rs
+++ b/src/gobjects.rs
@@ -11,6 +11,18 @@ pub enum GStatus {
     Ignore,
 }
 
+impl GStatus {
+    pub fn ignored(&self) -> bool {
+        self == &GStatus::Ignore
+    }
+    pub fn need_generate(&self) -> bool {
+        self == &GStatus::Generate
+    }
+    pub fn normal(&self) -> bool {
+        self == &GStatus::Generate || self == &GStatus::Manual
+    }
+}
+
 impl Default for GStatus {
     fn default() -> GStatus { GStatus::Ignore }
 }

--- a/src/library.rs
+++ b/src/library.rs
@@ -192,7 +192,9 @@ pub struct Alias {
 
 pub struct Constant {
     pub name: String,
+    pub c_identifier: String,
     pub typ: TypeId,
+    pub c_type: String,
     pub value: String,
 }
 


### PR DESCRIPTION
`c:type` parsed but unused, `name` used only for check for ignoring.
On build some warning about overflowing `pub const G_MININT8:i8 = 128;` etc.
Not sure about names checker functions for `GStatus`.
May be better remove `only_for_gtk` as it contains only `GTK_ENTRY_BUFFER_MAX_SIZE`