### PR TITLE
Some comsetic changes

### DIFF
--- a/src/codegen/sys/ffi_type.rs
+++ b/src/codegen/sys/ffi_type.rs
@@ -148,7 +148,7 @@ fn fix_name(env: &Env, type_id: library::TypeId, name: &str) -> Result {
                     Ok(name.into())
                 }
                 else {
-                    Ok(format!("{}_ffi::{}", crate_name("GLib"), name))
+                    Ok(format!("{}::{}", crate_name("GLib"), name))
                 }
             }
             _ => Ok(name.into())
@@ -157,7 +157,7 @@ fn fix_name(env: &Env, type_id: library::TypeId, name: &str) -> Result {
         let name_with_prefix = if type_id.ns_id == library::MAIN_NAMESPACE {
             name.into()
         } else {
-            format!("{}_ffi::{}", fix_namespace(env, type_id), name)
+            format!("{}::{}", fix_namespace(env, type_id), name)
         };
         if env.type_status_sys(&type_id.full_name(&env.library)).ignored() {
             Err(name_with_prefix)

--- a/src/codegen/sys/lib_.rs
+++ b/src/codegen/sys/lib_.rs
@@ -37,7 +37,7 @@ fn generate_lib<W: Write>(w: &mut W, env: &Env) -> Result<()>{
     try!(statics::after_extern_crates(w));
 
     if env.config.library_name != "GLib" {
-        try!(statics::use_glib_ffi(w));
+        try!(statics::use_glib(w));
     }
     match &*env.config.library_name {
         "GLib" => try!(statics::only_for_glib(w)),
@@ -75,7 +75,7 @@ fn generate_lib<W: Write>(w: &mut W, env: &Env) -> Result<()>{
 
 fn generate_extern_crates<W: Write>(w: &mut W, env: &Env) -> Result<()>{
     for library_name in &env.config.external_libraries {
-        try!(writeln!(w, "extern crate {0}_sys as {0}_ffi;", crate_name(library_name)));
+        try!(writeln!(w, "extern crate {0}_sys as {0};", crate_name(library_name)));
     }
 
     Ok(())

--- a/src/codegen/sys/statics.rs
+++ b/src/codegen/sys/statics.rs
@@ -26,11 +26,11 @@ pub fn after_extern_crates<W: Write>(w: &mut W) -> Result<()>{
     write_vec(w, &v)
 }
 
-pub fn use_glib_ffi<W: Write>(w: &mut W) -> Result<()>{
+pub fn use_glib<W: Write>(w: &mut W) -> Result<()>{
     let v = vec![
 "",
 "#[allow(unused_imports)]",
-"use glib_ffi::{gboolean, gconstpointer, gpointer, GType, Volatile};",
+"use glib::{gboolean, gconstpointer, gpointer, GType, Volatile};",
     ];
 
     write_vec(w, &v)

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -237,15 +237,15 @@ impl Library {
         if name == "Atom" && self.namespace(ns_id).name == "Gdk" {
             // the gir definitions don't reflect the following correctly
             // typedef struct _GdkAtom *GdkAtom;
-            name = "_Atom";
-            c_type = "_GdkAtom";
-            let tid = self.find_or_stub_type(ns_id, "Gdk._Atom");
+            name = "Atom_";
+            c_type = "GdkAtom_";
+            let tid = self.find_or_stub_type(ns_id, "Gdk.Atom_");
             self.add_type(ns_id, "Atom", Type::Alias(
                 Alias {
                     name: "Atom".into(),
                     c_identifier: "GdkAtom".into(),
                     typ: tid,
-                    target_c_type: "_GdkAtom*".into(),
+                    target_c_type: "GdkAtom_*".into(),
                 }));
         }
 


### PR DESCRIPTION
It seems redundant to use the `_ffi` suffix in the sys crates when referring to sibling crates. All of this is FFI already.