### PR TITLE
Partially implement container handling

### DIFF
--- a/src/analysis/functions.rs
+++ b/src/analysis/functions.rs
@@ -7,7 +7,7 @@ use analysis::return_value;
 use analysis::rust_type::*;
 use analysis::upcasts::Upcasts;
 use env::Env;
-use library;
+use library::{self, Nullable};
 use traits::*;
 use version::Version;
 
@@ -55,8 +55,9 @@ fn analyze_function(env: &Env, func: &library::Function, class_tid: library::Typ
                 panic!("Too many parameters upcasts for {}", func.c_identifier.as_ref().unwrap())
             }
         }
-        if parameter_rust_type(env, par.typ, par.direction)
-            .is_err() { commented = true; }
+        if parameter_rust_type(env, par.typ, par.direction, Nullable(false)).is_err() {
+            commented = true;
+        }
     }
 
     let outs = out_parameters::analyze(func);

--- a/src/analysis/return_value.rs
+++ b/src/analysis/return_value.rs
@@ -3,7 +3,7 @@ use std::collections::HashSet;
 use analysis::c_type::rustify_pointers;
 use analysis::rust_type::*;
 use env::Env;
-use library;
+use library::{self, Nullable};
 
 pub struct Info {
     pub parameter: Option<library::Parameter>,
@@ -29,7 +29,7 @@ pub fn analyze(env: &Env, func: &library::Function, class_tid: library::TypeId,
     };
 
     let commented = if func.ret.typ == Default::default() { false } else {
-        parameter_rust_type(env, func.ret.typ, func.ret.direction).is_err()
+        parameter_rust_type(env, func.ret.typ, func.ret.direction, Nullable(false)).is_err()
     };
 
     if func.kind == library::FunctionKind::Constructor {

--- a/src/analysis/type_kind.rs
+++ b/src/analysis/type_kind.rs
@@ -5,6 +5,7 @@ pub enum TypeKind {
     Direct,     //coded without conversion
     Converted,  //coded with from_glib
     Pointer,    //coded with from_glib_xxx
+    Container,  //coded with from_glib_xxx
     Object,     //coded with from_glib_xxx
     Interface,  //coded with from_glib_xxx
     Enumeration,//coded without conversion
@@ -19,8 +20,8 @@ impl TypeKind {
     pub fn of(library: &Library, type_id: TypeId) -> TypeKind {
         use library::Type::*;
         use library::Fundamental::*;
-        match library.type_(type_id) {
-            &Fundamental(fund) => match fund {
+        match *library.type_(type_id) {
+            Fundamental(fund) => match fund {
                 Boolean => TypeKind::Converted,
                 Int8 => TypeKind::Direct,
                 UInt8 => TypeKind::Direct,
@@ -51,9 +52,10 @@ impl TypeKind {
                 None => TypeKind::Unknown,
                 Unsupported => TypeKind::Unknown,
             },
-            &Enumeration(_) => TypeKind::Enumeration,
-            &Interface(_) => TypeKind::Interface,
-            &Class(_) => TypeKind::Object,
+            Enumeration(_) => TypeKind::Enumeration,
+            Interface(_) => TypeKind::Interface,
+            Class(_) => TypeKind::Object,
+            List(..) => TypeKind::Container,
             _ => TypeKind::Unknown,
         }
     }

--- a/src/codegen/parameter.rs
+++ b/src/codegen/parameter.rs
@@ -1,5 +1,5 @@
 use env::Env;
-use library;
+use library::{self, Nullable};
 use analysis::type_kind::TypeKind;
 use analysis::rust_type::parameter_rust_type;
 use analysis::upcasts::Upcasts;
@@ -14,11 +14,19 @@ impl ToParameter for library::Parameter {
         if self.instance_parameter {
             "&self".into()
         } else {
-            let mut type_str: String;
+            let type_str: String;
             match upcasts.get_parameter_type_alias(&self.name) {
-                Some(t) => type_str = format!("&{}", t),
+                Some(t) => {
+                    if self.nullable {
+                        type_str = format!("Option<&{}>", t)
+                    }
+                    else {
+                        type_str = format!("&{}", t)
+                    }
+                }
                 None => {
-                    let rust_type = parameter_rust_type(env, self.typ, self.direction);
+                    let rust_type = parameter_rust_type(env, self.typ, self.direction,
+                        Nullable(self.nullable));
                     let type_name = rust_type.as_str();
                     let kind = TypeKind::of(&env.library, self.typ);
                     type_str = match kind {
@@ -26,9 +34,6 @@ impl ToParameter for library::Parameter {
                         _ => type_name.into()
                     }
                 }
-            }
-            if self.nullable {
-                type_str = format!("Option<{}>", type_str);
             }
             format_parameter(&self.name, &type_str)
         }

--- a/src/codegen/parameter.rs
+++ b/src/codegen/parameter.rs
@@ -1,5 +1,5 @@
 use env::Env;
-use library::{self, Nullable};
+use library;
 use analysis::type_kind::TypeKind;
 use analysis::rust_type::parameter_rust_type;
 use analysis::upcasts::Upcasts;
@@ -17,7 +17,7 @@ impl ToParameter for library::Parameter {
             let type_str: String;
             match upcasts.get_parameter_type_alias(&self.name) {
                 Some(t) => {
-                    if self.nullable {
+                    if *self.nullable {
                         type_str = format!("Option<&{}>", t)
                     }
                     else {
@@ -26,7 +26,7 @@ impl ToParameter for library::Parameter {
                 }
                 None => {
                     let rust_type = parameter_rust_type(env, self.typ, self.direction,
-                        Nullable(self.nullable));
+                        self.nullable);
                     let type_name = rust_type.as_str();
                     let kind = TypeKind::of(&env.library, self.typ);
                     type_str = match kind {

--- a/src/codegen/return_value.rs
+++ b/src/codegen/return_value.rs
@@ -1,6 +1,6 @@
 use analysis;
 use env::Env;
-use library::{self, Nullable, ParameterDirection};
+use library::{self, ParameterDirection};
 use analysis::type_kind::TypeKind;
 use analysis::rust_type::parameter_rust_type;
 use traits::*;
@@ -11,7 +11,7 @@ pub trait ToReturnValue {
 
 impl ToReturnValue for library::Parameter {
     fn to_return_value(&self, env: &Env) -> String {
-        let rust_type = parameter_rust_type(env, self.typ, self.direction, Nullable(self.nullable));
+        let rust_type = parameter_rust_type(env, self.typ, self.direction, self.nullable);
         let name = rust_type.as_str();
         let kind = TypeKind::of(&env.library, self.typ);
         let type_str = match kind {
@@ -48,8 +48,7 @@ pub fn out_parameters_as_return(env: &Env, analysis: &analysis::functions::Info)
 
 fn out_parameter_as_return(par: &library::Parameter, env: &Env) -> String {
     //TODO: upcasts?
-    let rust_type = parameter_rust_type(env, par.typ, ParameterDirection::Return,
-        Nullable(par.nullable));
+    let rust_type = parameter_rust_type(env, par.typ, ParameterDirection::Return, par.nullable);
     let name = rust_type.as_str();
     let kind = TypeKind::of(&env.library, par.typ);
     match kind {

--- a/src/codegen/return_value.rs
+++ b/src/codegen/return_value.rs
@@ -1,6 +1,6 @@
 use analysis;
 use env::Env;
-use library;
+use library::{self, Nullable, ParameterDirection};
 use analysis::type_kind::TypeKind;
 use analysis::rust_type::parameter_rust_type;
 use traits::*;
@@ -11,16 +11,13 @@ pub trait ToReturnValue {
 
 impl ToReturnValue for library::Parameter {
     fn to_return_value(&self, env: &Env) -> String {
-        let rust_type = parameter_rust_type(env, self.typ, self.direction);
+        let rust_type = parameter_rust_type(env, self.typ, self.direction, Nullable(self.nullable));
         let name = rust_type.as_str();
         let kind = TypeKind::of(&env.library, self.typ);
         let type_str = match kind {
             TypeKind::Unknown => format!("/*Unknown kind*/{}", name),
             //TODO: records as in gtk_container_get_path_for_child
-            TypeKind::Direct |
-                TypeKind::Enumeration => name.into(),
-
-            _ => maybe_optional(name, self)
+            _ => name.into(),
         };
         format!(" -> {}", type_str)
     }
@@ -32,14 +29,6 @@ impl ToReturnValue for analysis::return_value::Info {
             Some(ref par) => par.to_return_value(env),
             None => String::new(),
         }
-    }
-}
-
-fn maybe_optional(name: &str, par: &library::Parameter) -> String {
-    if par.nullable {
-        format!("Option<{}>", name)
-    } else {
-        name.into()
     }
 }
 
@@ -59,16 +48,12 @@ pub fn out_parameters_as_return(env: &Env, analysis: &analysis::functions::Info)
 
 fn out_parameter_as_return(par: &library::Parameter, env: &Env) -> String {
     //TODO: upcasts?
-    let rust_type = parameter_rust_type(env, par.typ, library::ParameterDirection::Return);
+    let rust_type = parameter_rust_type(env, par.typ, ParameterDirection::Return,
+        Nullable(par.nullable));
     let name = rust_type.as_str();
     let kind = TypeKind::of(&env.library, par.typ);
     match kind {
         TypeKind::Unknown => format!("/*Unknown kind*/{}", name),
-
-        TypeKind::Direct |
-            TypeKind::Converted |
-            TypeKind::Enumeration => name.into(),
-
-        _ => format!("Option<{}>", name),
+        _ => name.into(),
     }
 }

--- a/src/codegen/sys/lib_.rs
+++ b/src/codegen/sys/lib_.rs
@@ -123,10 +123,11 @@ fn generate_bitfields<W: Write>(w: &mut W, items: &[&Bitfield])
 fn generate_constants<W: Write>(w: &mut W, env: &Env, constants: &[Constant]) -> Result<()> {
     try!(writeln!(w, ""));
     for constant in constants {
-        let (mut comment, mut type_) = match parameter_rust_type(env, constant.typ, ParameterDirection::In) {
-            Ok(x) => ("", x),
-            Err(x) => ("//", x),
-        };
+        let (mut comment, mut type_) =
+            match parameter_rust_type(env, constant.typ, ParameterDirection::In, Nullable(false)) {
+                Ok(x) => ("", x),
+                Err(x) => ("//", x),
+            };
         if env.type_status_sys(&format!("{}.{}", env.config.library_name,
             constant.name)).ignored() {
             comment = "//";

--- a/src/codegen/translate_from_glib.rs
+++ b/src/codegen/translate_from_glib.rs
@@ -35,12 +35,12 @@ impl TranslateFromGlib for analysis::return_value::Info {
                 Some(tid) => {
                     let rust_type = rust_type(env, tid);
                     let from_glib_xxx = from_glib_xxx(par.transfer);
-                    let prefix = if par.nullable {
+                    let prefix = if *par.nullable {
                         format!("Option::<{}>::{}", rust_type.as_str(), from_glib_xxx.0)
                     } else {
                         format!("{}::{}", rust_type.as_str(), from_glib_xxx.0)
                     };
-                    let suffix_function = if par.nullable {
+                    let suffix_function = if *par.nullable {
                         "map(Downcast::downcast_unchecked)"
                     } else {
                         "downcast_unchecked()"

--- a/src/codegen/translate_from_glib.rs
+++ b/src/codegen/translate_from_glib.rs
@@ -19,6 +19,10 @@ impl TranslateFromGlib for library::Parameter {
                 TypeKind::Enumeration => (String::new(), String::new()),
             TypeKind::Pointer | //Checked only for Option<String>
                 TypeKind::Object => from_glib_xxx(self.transfer),
+            TypeKind::Container => {
+                let trans = from_glib_xxx(self.transfer);
+                (format!("FromGlibPtrContainer::{}", trans.0), trans.1)
+            }
             _ => (format!("TODO {:?}:", kind), String::new()),
         }
     }
@@ -58,6 +62,6 @@ fn from_glib_xxx(transfer: library::Transfer) -> (String, String) {
     match transfer {
         None => ("from_glib_none(".into(), ")".into()),
         Full => ("from_glib_full(".into(), ")".into()),
-        Container => ("TODO:".into(), String::new()),
+        Container => ("from_glib_container(".into(), ")".into()),
     }
 }

--- a/src/codegen/translate_to_glib.rs
+++ b/src/codegen/translate_to_glib.rs
@@ -8,7 +8,7 @@ pub trait TranslateToGlib {
 impl TranslateToGlib for library::Parameter {
     fn translate_to_glib(&self, library: &library::Library, upcast: bool) -> String {
         let kind = TypeKind::of(library, self.typ);
-        let upcast_str = match (upcast, self.nullable) {
+        let upcast_str = match (upcast, *self.nullable) {
             (true, true) => ".map(Upcast::upcast)",
             (true, false) => ".upcast()",
             _ => "",

--- a/src/codegen/translate_to_glib.rs
+++ b/src/codegen/translate_to_glib.rs
@@ -18,6 +18,7 @@ impl TranslateToGlib for library::Parameter {
             TypeKind::Direct |
                 TypeKind::Enumeration => self.name.clone(),
             TypeKind::Pointer |
+                TypeKind::Container |
                 TypeKind::Object => {
                 if self.instance_parameter {
                     format!("self{}{}", upcast_str, to_glib_xxx(self.transfer))
@@ -36,6 +37,6 @@ fn to_glib_xxx(transfer: library::Transfer) -> &'static str {
     match transfer {
         None => ".to_glib_none().0",
         Full => ".to_glib_full()",
-        Container => "TODO:container",
+        Container => ".to_glib_container()",
     }
 }

--- a/src/library.rs
+++ b/src/library.rs
@@ -1,5 +1,6 @@
 use std::cmp::{Ord, Ordering, PartialOrd};
 use std::collections::{BTreeSet, HashMap, HashSet};
+use std::ops::Deref;
 use std::str::FromStr;
 use nameutil::split_namespace_name;
 use traits::*;
@@ -58,6 +59,16 @@ impl FromStr for ParameterDirection {
 impl Default for ParameterDirection {
     fn default() -> ParameterDirection {
         ParameterDirection::In
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct Nullable(pub bool);
+
+impl Deref for Nullable {
+    type Target = bool;
+    fn deref(&self) -> &bool {
+        &self.0
     }
 }
 

--- a/src/library.rs
+++ b/src/library.rs
@@ -1,6 +1,6 @@
 use std::cmp::{Ord, Ordering, PartialOrd};
 use std::collections::{BTreeSet, HashMap, HashSet};
-use std::ops::Deref;
+use std::ops::{Deref, DerefMut};
 use std::str::FromStr;
 use nameutil::split_namespace_name;
 use traits::*;
@@ -69,6 +69,12 @@ impl Deref for Nullable {
     type Target = bool;
     fn deref(&self) -> &bool {
         &self.0
+    }
+}
+
+impl DerefMut for Nullable {
+    fn deref_mut(&mut self) -> &mut bool {
+        &mut self.0
     }
 }
 
@@ -245,7 +251,7 @@ pub struct Parameter {
     pub instance_parameter: bool,
     pub direction: ParameterDirection,
     pub transfer: Transfer,
-    pub nullable: bool,
+    pub nullable: Nullable,
     pub allow_none: bool,
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -679,7 +679,7 @@ impl Library {
                 instance_parameter: false,
                 direction: ParameterDirection::Out,
                 transfer: Transfer::Full,
-                nullable: true,
+                nullable: Nullable(true),
                 allow_none: true,
             });
         }
@@ -799,7 +799,7 @@ impl Library {
                 instance_parameter: instance_parameter,
                 direction: direction,
                 transfer: transfer,
-                nullable: nullable,
+                nullable: Nullable(nullable),
                 allow_none: allow_none,
             })
         }
@@ -811,7 +811,7 @@ impl Library {
                 instance_parameter: instance_parameter,
                 direction: Default::default(),
                 transfer: Transfer::None,
-                nullable: nullable,
+                nullable: Nullable(false),
                 allow_none: allow_none,
             })
         }


### PR DESCRIPTION
`GList` return value is translated to `Vec` correctly now.
Somewhat generalized passing input parameters by reference.

```patch
-    //fn get_children(&self) -> /*Unknown kind*/Unknown rust type: "List TypeId { ns_id: 1, id: 3 }";
-    //fn get_focus_chain(&self, focusable_widgets: /*Unknown kind*/Unknown rust type: "List TypeId { ns_id: 1, id: 3 }") -> bool;
+    fn get_children(&self) -> Vec<Widget>;
+    //fn get_focus_chain(&self, focusable_widgets: /*Unimplemented*/Vec<Widget>) -> bool;

-    //fn set_focus_chain(&self, focusable_widgets: /*Unknown kind*/Unknown rust type: "List TypeId { ns_id: 1, id: 3 }");
+    //fn set_focus_chain(&self, focusable_widgets: /*Unimplemented*/&[Widget]);

-    //fn set_icon(&self, icon: Option<gdk_pixbuf::Pixbuf>);
-    //fn set_icon_from_file(&self, filename: Fundamental: Filename, error: Option</*Unknown kind*/Unknown rust type: "Error">) -> bool;
-    //fn set_icon_list(&self, list: /*Unknown kind*/Unknown rust type: "List TypeId { ns_id: 7, id: 2 }");
+    //fn set_icon(&self, icon: Option<&gdk_pixbuf::Pixbuf>);
+    //fn set_icon_from_file(&self, filename: Fundamental: Filename, error: /*Unknown kind*/Unknown rust type: "Error") -> bool;
+    //fn set_icon_list(&self, list: /*Unimplemented*/&[gdk_pixbuf::Pixbuf]);
```