### PR TITLE
Working toward object_reform

### DIFF
--- a/Gir_Gtk.toml
+++ b/Gir_Gtk.toml
@@ -17,45 +17,26 @@ status = "manual"
 
 [[object]]
 name = "Gtk.Container"
-status = "generate"
+status = "manual"
 
 [[object]]
 name = "Gtk.Bin"
 status = "generate"
 
 [[object]]
-name = "Gtk.Window"
+name = "Gtk.Box"
 status = "generate"
+
+[[object]]
+name = "Gtk.Window"
+status = "manual"
 
 [[object]]
 name = "Gtk.Dialog"
-status = "generate"
+status = "manual"
 
 [[object]]
-name = "Gtk.DrawingArea"
-status = "generate"
-
-[[object]]
-name = "Gtk.Switch"
-status = "generate"
-
-[[object]]
-name = "Gtk.Range"
-non_nullable = [
-    "get_adjustment",
-]
-status = "generate"
-
-[[object]]
-name = "Gtk.Scale"
-status = "generate"
-
-[[object]]
-name = "Gtk.RadioButton"
-status = "generate"
-
-[[object]]
-name = "Gtk.AboutDialog"
+name = "Gtk.Misc"
 status = "generate"
 
 [[object]]
@@ -75,5 +56,96 @@ name = "Gtk.Orientable"
 status = "manual"
 
 [[object]]
+name = "Gtk.AccelGroup"
+status = "generate"
+
+[[object]]
 name = "Gtk.Alignment"
+status = "manual"
+
+[[object]]
+name = "Gtk.ActionBar"
+status = "generate"
+
+[[object]]
+name = "Gtk.Alignment"
+status = "generate"
+
+[[object]]
+name = "Gtk.Arrow"
+status = "generate"
+
+[[object]]
+name = "Gtk.AppChooserDialog"
+status = "generate"
+non_nullable = [
+    "get_widget",
+]
+
+[[object]]
+name = "Gtk.AppChooserWidget"
+status = "generate"
+
+[[object]]
+name = "Gtk.Button"
+status = "generate"
+
+[[object]]
+name = "Gtk.ButtonBox"
+status = "generate"
+
+[[object]]
+name = "Gtk.Calendar"
+status = "generate"
+
+[[object]]
+name = "Gtk.CheckButton"
+status = "generate"
+
+[[object]]
+name = "Gtk.ColorButton"
+status = "generate"
+
+[[object]]
+name = "Gtk.DrawingArea"
+status = "generate"
+
+[[object]]
+name = "Gtk.FontButton"
+status = "generate"
+
+[[object]]
+name = "Gtk.LinkButton"
+status = "generate"
+
+[[object]]
+name = "Gtk.Menu"
+status = "generate"
+
+[[object]]
+name = "Gtk.MenuButton"
+status = "generate"
+
+[[object]]
+name = "Gtk.MenuItem"
+status = "generate"
+
+[[object]]
+name = "Gtk.MenuShell"
+status = "generate"
+
+[[object]]
+name = "Gtk.Popover"
+status = "generate"
+
+[[object]]
+name = "Gtk.RadioButton"
+status = "generate"
+
+[[object]]
+name = "Gtk.ScaleButton"
+status = "generate"
+
+[[object]]
+name = "Gtk.ToggleButton"
 status = "generate"

--- a/Gir_Gtk.toml
+++ b/Gir_Gtk.toml
@@ -87,6 +87,10 @@ name = "Gtk.AppChooserWidget"
 status = "generate"
 
 [[object]]
+name = "Gtk.AspectFrame"
+status = "generate"
+
+[[object]]
 name = "Gtk.Button"
 status = "generate"
 
@@ -111,7 +115,47 @@ name = "Gtk.DrawingArea"
 status = "generate"
 
 [[object]]
+name = "Gtk.Fixed"
+status = "generate"
+
+[[object]]
+name = "Gtk.FlowBox"
+status = "generate"
+
+[[object]]
+name = "Gtk.FlowBoxChild"
+status = "generate"
+
+[[object]]
 name = "Gtk.FontButton"
+status = "generate"
+
+[[object]]
+name = "Gtk.Frame"
+status = "generate"
+
+[[object]]
+name = "Gtk.Grid"
+status = "generate"
+
+[[object]]
+name = "Gtk.HeaderBar"
+status = "generate"
+
+[[object]]
+name = "Gtk.Image"
+status = "generate"
+
+[[object]]
+name = "Gtk.Label"
+status = "generate"
+
+[[object]]
+name = "Gtk.Layout"
+status = "generate"
+
+[[object]]
+name = "Gtk.LevelBar"
 status = "generate"
 
 [[object]]
@@ -149,3 +193,11 @@ status = "generate"
 [[object]]
 name = "Gtk.ToggleButton"
 status = "generate"
+
+[[object]]
+name = "GdkPixbuf.Pixbuf"
+status = "manual"
+
+[[object]]
+name = "GdkPixbuf.PixbufAnimation"
+status = "manual"

--- a/src/analysis/functions.rs
+++ b/src/analysis/functions.rs
@@ -74,7 +74,12 @@ fn analyze_function(env: &Env, func: &library::Function, class_tid: library::Typ
 
     if !commented {
         for s in used_types {
-            all_used_types.insert(s);
+            if let Some(i) = s.find("::") {
+                all_used_types.insert(s[..i].into());
+            }
+            else {
+                all_used_types.insert(s);
+            }
         }
     }
 

--- a/src/analysis/general.rs
+++ b/src/analysis/general.rs
@@ -7,6 +7,7 @@ pub struct StatusedTypeId{
     pub status: GStatus,
 }
 
+/*
 fn widget_tid(library: &Library) -> TypeId {
     library.find_type(0, "Gtk.Widget").expect("type Gtk.Widget not found")
 }
@@ -18,3 +19,4 @@ pub fn is_widget(name: &str, library: &Library) -> bool {
         _ => false,
     }
 }
+*/

--- a/src/analysis/object.rs
+++ b/src/analysis/object.rs
@@ -7,6 +7,7 @@ use nameutil::*;
 use super::*;
 use super::type_kind::TypeKind;
 use traits::*;
+use version::Version;
 
 #[derive(Default)]
 pub struct Info {
@@ -23,6 +24,7 @@ pub struct Info {
     pub has_methods: bool,
     pub has_functions: bool,
     pub used_types: HashSet<String>,
+    pub version: Option<Version>,
 }
 
 impl Info {
@@ -84,6 +86,8 @@ pub fn new(env: &Env, obj: &GObject) -> Info {
     let functions =
         functions::analyze(env, klass, class_tid, &obj.non_nullable_overrides, &mut used_types);
 
+    let version = functions.iter().filter_map(|f| f.version).min();
+
     //don't `use` yourself
     used_types.remove(&name);
 
@@ -98,6 +102,7 @@ pub fn new(env: &Env, obj: &GObject) -> Info {
         has_ignored_parents: has_ignored_parents,
         functions: functions,
         used_types: used_types,
+        version: version,
         .. Default::default()
     };
 

--- a/src/analysis/parents.rs
+++ b/src/analysis/parents.rs
@@ -15,6 +15,8 @@ pub fn analyze(env: &Env, type_: &Class, used_types: &mut HashSet<String>)
     for &parent_tid in &type_.parents {
         let parent_type = env.type_(parent_tid).to_ref_as::<Class>();
 
+        if parent_type.c_type == "GObject" { break }
+
         let status = env.type_status(&parent_tid.full_name(&env.library));
 
         parents.push(StatusedTypeId{

--- a/src/analysis/return_value.rs
+++ b/src/analysis/return_value.rs
@@ -1,5 +1,3 @@
-use std::collections::HashSet;
-
 use analysis::c_type::rustify_pointers;
 use analysis::rust_type::*;
 use env::Env;
@@ -12,10 +10,12 @@ pub struct Info {
 }
 
 pub fn analyze(env: &Env, func: &library::Function, class_tid: library::TypeId,
-    non_nullable_overrides: &[String], used_types: &mut HashSet<String>) -> Info {
+    non_nullable_overrides: &[String], used_types: &mut Vec<String>) -> Info {
 
     let mut parameter = if func.ret.typ == Default::default() { None } else {
-        used_rust_type(env, func.ret.typ).ok().map(|s| used_types.insert(s));
+        if let Ok(s) = used_rust_type(env, func.ret.typ) {
+            used_types.push(s);
+        }
         // Since GIRs are bad at specifying return value nullability, assume
         // any returned pointer is nullable unless overridden by the config.
         let mut nullable = func.ret.nullable;

--- a/src/analysis/rust_type.rs
+++ b/src/analysis/rust_type.rs
@@ -54,6 +54,7 @@ fn rust_type_full(env: &Env, type_id: library::TypeId, nullable: Nullable, by_re
         },
 
         Enumeration(ref enum_) => Ok(enum_.name.clone()),
+        Bitfield(ref bitfield) => Ok(bitfield.name.clone()),
         Interface(ref interface) => Ok(interface.name.clone()),
         Class(ref klass) => Ok(klass.name.clone()),
         List(inner_tid) => {
@@ -86,10 +87,11 @@ fn rust_type_full(env: &Env, type_id: library::TypeId, nullable: Nullable, by_re
 
 pub fn used_rust_type(env: &Env, type_id: library::TypeId) -> Result {
     use library::Type::*;
-    match env.library.type_(type_id) {
-        &Enumeration(_) |
-            &Interface(_) |
-            &Class(_) => rust_type(env, type_id),
+    match *env.library.type_(type_id) {
+        Bitfield(..) |
+            Class(..) |
+            Enumeration(..) |
+            Interface(..) => rust_type(env, type_id),
         _ => Err("Don't need use".into()),
     }
 }
@@ -118,7 +120,8 @@ pub fn parameter_rust_type(env: &Env, type_id:library::TypeId,
             }
         },
 
-        Enumeration(_) => format_parameter(rust_type, direction),
+        Enumeration(..) |
+            Bitfield(..) => format_parameter(rust_type, direction),
 
         Class(..) => {
             match direction {

--- a/src/analysis/rust_type.rs
+++ b/src/analysis/rust_type.rs
@@ -46,6 +46,7 @@ fn rust_type_full(env: &Env, type_id: library::TypeId, nullable: Nullable, by_re
                 Double => ok("f64"),
 
                 Utf8 => if by_ref { ok("str") } else { ok("String") },
+                Filename => if by_ref { ok("str") } else { ok("String") },
 
                 Type => ok("types::Type"),
                 Unsupported => err("Unsupported"),
@@ -102,6 +103,7 @@ pub fn parameter_rust_type(env: &Env, type_id:library::TypeId,
     let type_ = env.library.type_(type_id);
     let by_ref = match *type_ {
         Fundamental(library::Fundamental::Utf8) |
+            Fundamental(library::Fundamental::Filename) |
             Class(..) |
             List(..) => direction == library::ParameterDirection::In,
         _ => false,
@@ -109,7 +111,7 @@ pub fn parameter_rust_type(env: &Env, type_id:library::TypeId,
     let rust_type = rust_type_full(env, type_id, nullable, by_ref);
     match *type_ {
         Fundamental(fund) => {
-            if fund == library::Fundamental::Utf8 {
+            if fund == library::Fundamental::Utf8 || fund == library::Fundamental::Filename {
                 match direction {
                     library::ParameterDirection::In |
                         library::ParameterDirection::Return => rust_type,

--- a/src/analysis/type_kind.rs
+++ b/src/analysis/type_kind.rs
@@ -9,6 +9,7 @@ pub enum TypeKind {
     Object,     //coded with from_glib_xxx
     Interface,  //coded with from_glib_xxx
     Enumeration,//coded without conversion
+    Bitfield,   //coded without conversion
     Unknown,
 }
 
@@ -52,6 +53,7 @@ impl TypeKind {
                 None => TypeKind::Unknown,
                 Unsupported => TypeKind::Unknown,
             },
+            Bitfield(_) => TypeKind::Bitfield,
             Enumeration(_) => TypeKind::Enumeration,
             Interface(_) => TypeKind::Interface,
             Class(_) => TypeKind::Object,

--- a/src/codegen/function.rs
+++ b/src/codegen/function.rs
@@ -36,6 +36,7 @@ pub fn generate<W: Write>(w: &mut W, env: &Env, analysis: &analysis::functions::
             }
             try!(writeln!(w, "{}}}", tabs(indent)));
         }
+        try!(writeln!(w, ""));
     }
 
     Ok(())

--- a/src/codegen/general.rs
+++ b/src/codegen/general.rs
@@ -77,16 +77,24 @@ pub fn impl_static_type<W: Write>(w: &mut W, type_name: &str, glib_func_name: &s
 }
 
 pub fn version_condition<W: Write>(w: &mut W, library_name: &str, min_cfg_version: Version,
-    version: Option<Version>, commented: bool, indent: i32) -> Result<()> {
-    if let Some(v) = version {
-        if v >= min_cfg_version {
-            let comment = if commented { "//" } else { "" };
-            try!(writeln!(w, "{}{}#[cfg({})]", tabs(indent), comment,
-                v.to_cfg(&crate_name(library_name))));
-        }
+        version: Option<Version>, commented: bool, indent: i32) -> Result<()> {
+    let s = version_condition_string(library_name, min_cfg_version, version, commented, indent);
+    if let Some(s) = s {
+        try!(writeln!(w, "{}", s));
     }
-
     Ok(())
+}
+
+pub fn version_condition_string(library_name: &str, min_cfg_version: Version,
+        version: Option<Version>, commented: bool, indent: i32) -> Option<String> {
+    match version {
+        Some(v) if v >= min_cfg_version => {
+            let comment = if commented { "//" } else { "" };
+            Some(format!("{}{}#[cfg({})]", tabs(indent), comment,
+                v.to_cfg(&crate_name(library_name))))
+        }
+        _ => None
+    }
 }
 
 //TODO: convert to macro with usage

--- a/src/codegen/general.rs
+++ b/src/codegen/general.rs
@@ -57,7 +57,6 @@ pub fn impl_parents<W: Write>(w: &mut W, type_name: &str, parents: &[StatusedTyp
 }
 
 pub fn impl_interfaces<W: Write>(w: &mut W, type_name: &str, implements: &[StatusedTypeId]) -> Result<()>{
-    try!(writeln!(w, ""));
     for stid in implements {
         try!(writeln!(w, "unsafe impl Upcast<{}> for {} {{ }}", stid.name, type_name));
     }

--- a/src/codegen/translate_from_glib.rs
+++ b/src/codegen/translate_from_glib.rs
@@ -16,6 +16,7 @@ impl TranslateFromGlib for library::Parameter {
         match kind {
             TypeKind::Converted => ("from_glib(".into(), ")".into()),
             TypeKind::Direct |
+                TypeKind::Bitfield |
                 TypeKind::Enumeration => (String::new(), String::new()),
             TypeKind::Pointer | //Checked only for Option<String>
                 TypeKind::Object => from_glib_xxx(self.transfer),

--- a/src/codegen/translate_to_glib.rs
+++ b/src/codegen/translate_to_glib.rs
@@ -16,6 +16,7 @@ impl TranslateToGlib for library::Parameter {
         match kind {
             TypeKind::Converted => format!("{}{}", self.name, ".to_glib()"),
             TypeKind::Direct |
+                TypeKind::Bitfield |
                 TypeKind::Enumeration => self.name.clone(),
             TypeKind::Pointer |
                 TypeKind::Container |

--- a/src/codegen/widget.rs
+++ b/src/codegen/widget.rs
@@ -3,17 +3,10 @@ use std::io::{Result, Write};
 use analysis;
 use env::Env;
 use super::{function, general};
+use super::general::tabs;
 
 pub fn generate<W: Write>(w: &mut W, env: &Env, analysis: &analysis::object::Info) -> Result<()>{
     let type_ = analysis.type_(&env.library);
-
-    let mut generate_impl = false;
-    let mut generate_trait = false;
-
-    generate_impl |= analysis.has_constructors;
-    generate_impl |= analysis.has_functions;
-
-    if analysis.has_children { generate_trait |= true } else { generate_impl |= true };
 
     try!(general::start_comments(w, &env.config));
     try!(general::uses(w, &analysis.used_types));
@@ -21,14 +14,14 @@ pub fn generate<W: Write>(w: &mut W, env: &Env, analysis: &analysis::object::Inf
     try!(general::impl_parents(w, &analysis.name, &analysis.parents));
     try!(general::impl_interfaces(w, &analysis.name, &analysis.implements));
 
-    if generate_impl {
+    if generate_inherent(analysis) {
         try!(writeln!(w, ""));
         try!(writeln!(w, "impl {} {{", analysis.name));
         for func_analysis in &analysis.constructors() {
             try!(function::generate(w, env, func_analysis, false, false, 1));
         }
 
-        if !analysis.has_children {
+        if !generate_trait(analysis) {
             for func_analysis in &analysis.methods() {
                 try!(function::generate(w, env, func_analysis, false, false, 1));
             }
@@ -41,7 +34,7 @@ pub fn generate<W: Write>(w: &mut W, env: &Env, analysis: &analysis::object::Inf
     }
     try!(general::impl_static_type(w, &analysis.name, &type_.glib_get_type));
 
-    if generate_trait {
+    if generate_trait(analysis) {
         try!(writeln!(w, ""));
         try!(writeln!(w, "pub trait {}Ext {{", analysis.name));
         for func_analysis in &analysis.methods() {
@@ -58,4 +51,23 @@ pub fn generate<W: Write>(w: &mut W, env: &Env, analysis: &analysis::object::Inf
     }
 
     Ok(())
+}
+
+fn generate_inherent(analysis: &analysis::object::Info) -> bool {
+    analysis.has_constructors || analysis.has_functions || !analysis.has_children
+}
+
+fn generate_trait(analysis: &analysis::object::Info) -> bool {
+    analysis.has_children
+}
+
+pub fn generate_reexports(analysis: &analysis::object::Info, module_name: &str,
+        contents: &mut Vec<String>, traits: &mut Vec<String>) {
+    contents.push(format!(""));
+    contents.push(format!("mod {};", module_name));
+    contents.push(format!("pub use self::{}::{};", module_name, analysis.name));
+    if generate_trait(analysis) {
+        contents.push(format!("pub use self::{}::{}Ext;", module_name, analysis.name));
+        traits.push(format!("{}pub use super::{}Ext;", tabs(1), analysis.name));
+    }
 }

--- a/src/codegen/widget.rs
+++ b/src/codegen/widget.rs
@@ -61,13 +61,19 @@ fn generate_trait(analysis: &analysis::object::Info) -> bool {
     analysis.has_children
 }
 
-pub fn generate_reexports(analysis: &analysis::object::Info, module_name: &str,
+pub fn generate_reexports(env: &Env, analysis: &analysis::object::Info, module_name: &str,
         contents: &mut Vec<String>, traits: &mut Vec<String>) {
+    let version_cfg = general::version_condition_string(&env.config.library_name,
+        env.config.min_cfg_version, analysis.version, false, 0);
+    let (cfg, cfg_1) = match version_cfg {
+        Some(s) => (format!("{}\n", s), format!("{}{}\n", tabs(1), s)),
+        None => ("".into(), "".into()),
+    };
     contents.push(format!(""));
-    contents.push(format!("mod {};", module_name));
-    contents.push(format!("pub use self::{}::{};", module_name, analysis.name));
+    contents.push(format!("{}mod {};", cfg, module_name));
+    contents.push(format!("{}pub use self::{}::{};", cfg, module_name, analysis.name));
     if generate_trait(analysis) {
-        contents.push(format!("pub use self::{}::{}Ext;", module_name, analysis.name));
-        traits.push(format!("{}pub use super::{}Ext;", tabs(1), analysis.name));
+        contents.push(format!("{}pub use self::{}::{}Ext;", cfg, module_name, analysis.name));
+        traits.push(format!("{}{}pub use super::{}Ext;", cfg_1, tabs(1), analysis.name));
     }
 }

--- a/src/codegen/widgets.rs
+++ b/src/codegen/widgets.rs
@@ -18,15 +18,15 @@ pub fn generate(env: &Env) {
             continue;
         }
 
-        println!("Analyzing {:?}", obj.name);
+        info!("Analyzing {:?}", obj.name);
         let class_analysis = analysis::widget::new(env, obj);
         if class_analysis.has_ignored_parents {
-            println!("Skipping {:?}, it has ignored parents", obj.name);
+            warn!("Skipping {:?}, it has ignored parents", obj.name);
             continue;
         }
 
         let path = root_path.join(file_name(&class_analysis.full_name));
-        println!("Generating file {:?}", path);
+        info!("Generating file {:?}", path);
 
         save_to_file(path, env.config.make_backup,
             &mut |w| super::widget::generate(w, env, &class_analysis));

--- a/src/codegen/widgets.rs
+++ b/src/codegen/widgets.rs
@@ -1,13 +1,18 @@
-use std::path::PathBuf;
+use std::io::Write;
+use std::path::{Path, PathBuf};
 
 use analysis;
 use analysis::general::is_widget;
 use env::Env;
 use file_saver::*;
 use nameutil::*;
+use super::general;
 
 pub fn generate(env: &Env) {
-    let root_path = PathBuf::from(&env.config.target_path).join("src").join("widgets");
+    let root_path = PathBuf::from(&env.config.target_path).join("src").join("auto");
+
+    let mut mod_rs: Vec<String> = Vec::new();
+    let mut traits: Vec<String> = Vec::new();
 
     for obj in env.config.objects.values() {
         if !obj.status.need_generate() || !is_widget(&obj.name, &env.library){
@@ -26,5 +31,22 @@ pub fn generate(env: &Env) {
 
         save_to_file(path, env.config.make_backup,
             &mut |w| super::widget::generate(w, env, &class_analysis));
+
+        let mod_name = module_name(split_namespace_name(&class_analysis.full_name).1);
+        super::widget::generate_reexports(&class_analysis, &mod_name, &mut mod_rs, &mut traits);
     }
+
+    generate_mod_rs(env, &root_path, mod_rs, traits);
+}
+
+fn generate_mod_rs(env: &Env, root_path: &Path, mod_rs: Vec<String>, traits: Vec<String>) {
+    let path = root_path.join("mod.rs");
+    save_to_file(path, env.config.make_backup, &mut |w| {
+        try!(general::start_comments(w, &env.config));
+        try!(general::write_vec(w, &mod_rs));
+        try!(writeln!(w, ""));
+        try!(writeln!(w, "pub mod traits {{"));
+        try!(general::write_vec(w, &traits));
+        writeln!(w, "}}")
+    });
 }

--- a/src/codegen/widgets.rs
+++ b/src/codegen/widgets.rs
@@ -33,7 +33,8 @@ pub fn generate(env: &Env) {
             &mut |w| super::widget::generate(w, env, &class_analysis));
 
         let mod_name = module_name(split_namespace_name(&class_analysis.full_name).1);
-        super::widget::generate_reexports(&class_analysis, &mod_name, &mut mod_rs, &mut traits);
+        super::widget::generate_reexports(env, &class_analysis, &mod_name, &mut mod_rs,
+            &mut traits);
     }
 
     generate_mod_rs(env, &root_path, mod_rs, traits);

--- a/src/codegen/widgets.rs
+++ b/src/codegen/widgets.rs
@@ -2,7 +2,6 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 
 use analysis;
-use analysis::general::is_widget;
 use env::Env;
 use file_saver::*;
 use nameutil::*;
@@ -15,7 +14,7 @@ pub fn generate(env: &Env) {
     let mut traits: Vec<String> = Vec::new();
 
     for obj in env.config.objects.values() {
-        if !obj.status.need_generate() || !is_widget(&obj.name, &env.library){
+        if !obj.status.need_generate() {
             continue;
         }
 

--- a/src/gobjects.rs
+++ b/src/gobjects.rs
@@ -1,5 +1,5 @@
 use std::ascii::AsciiExt;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::str::FromStr;
 use toml::Value;
 
@@ -59,7 +59,7 @@ impl Default for GObject {
 }
 
 //TODO: ?change to HashMap<String, GStatus>
-pub type GObjects =  HashMap<String, GObject>;
+pub type GObjects =  BTreeMap<String, GObject>;
 
 pub fn parse_toml(toml_objects: &Value) -> GObjects {
     let mut objects = GObjects::new();

--- a/src/nameutil.rs
+++ b/src/nameutil.rs
@@ -67,10 +67,11 @@ pub fn module_name(name: &str) -> String {
     mangle_keywords(name.to_snake()).into_owned()
 }
 
+// If the mangling happened, guaranteed to return Owned.
 pub fn mangle_keywords<'a, S: Into<Cow<'a, str>>>(name: S) -> Cow<'a, str> {
     let name = name.into();
     if let Some(s) = KEYWORDS.get(&*name) {
-        s[..].into()
+        s.clone().into()
     }
     else {
         name

--- a/src/nameutil.rs
+++ b/src/nameutil.rs
@@ -64,7 +64,7 @@ pub fn crate_name(name: &str) -> String {
 }
 
 pub fn module_name(name: &str) -> String {
-    name.to_snake()
+    mangle_keywords(name.to_snake()).into_owned()
 }
 
 pub fn mangle_keywords<'a, S: Into<Cow<'a, str>>>(name: S) -> Cow<'a, str> {


### PR DESCRIPTION
* Move the generated files files to `mod auto` and generate `auto/mod.rs`
* Mangle module, function, parameter names if they conflict with Rust keywords
* Generate non-widget objects
* Add `Bitfield` and `Filename` support
* Minor internal and non-functional output tweaks