### PR TITLE
Add skip assertion if use objects or interfaces

### DIFF
--- a/src/analysis/safety_assertion_mode.rs
+++ b/src/analysis/safety_assertion_mode.rs
@@ -1,5 +1,6 @@
 use analysis::parameter::Parameter;
 use env::Env;
+use library;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum SafetyAssertionMode {
@@ -26,7 +27,7 @@ impl SafetyAssertionMode {
         }
         for par in params {
             match *env.library.type_(par.typ) {
-                Class(..) | Interface(..) if !*par.nullable
+                Class(..) | Interface(..) if !*par.nullable && par.typ.ns_id == library::MAIN_NAMESPACE
                     => return Skip,
                 _ => (),
             }

--- a/src/analysis/safety_assertion_mode.rs
+++ b/src/analysis/safety_assertion_mode.rs
@@ -4,6 +4,7 @@ use env::Env;
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum SafetyAssertionMode {
     None,
+    Skip,
     InMainThread,
 }
 
@@ -16,11 +17,19 @@ impl Default for SafetyAssertionMode {
 impl SafetyAssertionMode {
     pub fn of(env: &Env, params: &[Parameter]) -> SafetyAssertionMode {
         use self::SafetyAssertionMode::*;
+        use library::Type::*;
         if !env.config.generate_safety_asserts {
             return None;
         }
         if params.len() > 0 && params[0].instance_parameter {
             return None;
+        }
+        for par in params {
+            match *env.library.type_(par.typ) {
+                Class(..) | Interface(..) if !*par.nullable
+                    => return Skip,
+                _ => (),
+            }
         }
 
         InMainThread

--- a/src/chunk/chunk.rs
+++ b/src/chunk/chunk.rs
@@ -25,6 +25,7 @@ pub enum Chunk {
     FromGlibConversion{mode: conversion_from_glib::Mode, value: Box<Chunk>},
     OptionalReturn{condition: String, value: Box<Chunk>},
     AssertInitializedAndInMainThread,
+    AssertSkipInitialized,
 }
 
 pub fn chunks(ch: Chunk) -> Vec<Chunk> {

--- a/src/codegen/function_body_chunk.rs
+++ b/src/codegen/function_body_chunk.rs
@@ -110,6 +110,8 @@ impl Builder {
     fn add_assertion(&self, chunks: &mut Vec<Chunk>) {
         match self.assertion {
             SafetyAssertionMode::None => (),
+            SafetyAssertionMode::Skip =>
+                chunks.push(Chunk::AssertSkipInitialized),
             SafetyAssertionMode::InMainThread =>
                 chunks.push(Chunk::AssertInitializedAndInMainThread),
         }

--- a/src/writer/to_code.rs
+++ b/src/writer/to_code.rs
@@ -76,6 +76,8 @@ impl ToCode for Chunk {
             }
             AssertInitializedAndInMainThread =>
                 vec!["assert_initialized_main_thread!();".to_string()],
+            AssertSkipInitialized =>
+                vec!["skip_assert_initialized!();".to_string()],
         }
     }
 }


### PR DESCRIPTION
Closes #174
Cover both `Option<Widget>` and `&[]` (GLib.List) exclusions cases.